### PR TITLE
refactor: dont instantiate pipes without options

### DIFF
--- a/src/bans/bans.controller.ts
+++ b/src/bans/bans.controller.ts
@@ -16,7 +16,7 @@ export class BansController {
   @Get('/latest')
   @UseInterceptors(TimeInterceptor)
   async index(
-    @Query('limit', new DefaultValuePipe(10), new ParseIntPipe())
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe)
     limit: number,
   ) {
     return this.bansService.getBans(limit);

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -21,7 +21,7 @@ export class ProfileController {
 
   @Get(':steamid')
   async index(
-    @Param('steamid', new SteamId64Pipe()) steamId: string,
+    @Param('steamid', SteamId64Pipe) steamId: string,
     @Query(new ValidationPipe({ transform: true }))
     { formats }: ProfileQueryDto,
   ) {
@@ -41,10 +41,10 @@ export class ProfileController {
 
   @Get(':steamid/bans')
   async bans(
-    @Param('steamid', new SteamId64Pipe()) steamId: string,
-    @Query('details', new DefaultValuePipe(false), new ParseBoolPipe())
+    @Param('steamid', SteamId64Pipe) steamId: string,
+    @Query('details', new DefaultValuePipe(false), ParseBoolPipe)
     details: boolean,
-    @Query('previous', new DefaultValuePipe(false), new ParseBoolPipe())
+    @Query('previous', new DefaultValuePipe(false), ParseBoolPipe)
     previous: boolean,
   ) {
     return this.profileService.getProfileBans(steamId, details, previous);


### PR DESCRIPTION
Let nest take care of instantiating pipes without values